### PR TITLE
Allow editing and saving numeric UDFs

### DIFF
--- a/OpenTreeMap/src/OTM/OTMEnvironment.m
+++ b/OpenTreeMap/src/OTM/OTMEnvironment.m
@@ -361,6 +361,22 @@ NSString * const OTMEnvironmentDateStringShort = @"yyyy-MM-dd";
     }
 }
 
+- (BOOL)shouldMakeIntFormatterForField:(NSString*)field ofType:(id)dataType {
+    if ([dataType isKindOfClass:[NSString class]]) {
+        return ([dataType isEqualToString:@"int"] && ![field isEqualToString:@"species"]);
+    } else {
+        return NO;
+    }
+}
+
+- (BOOL)shouldMakeFloatFormatterForField:(NSString*)field ofType:(id)dataType {
+    if ([dataType isKindOfClass:[NSString class]]) {
+        return ([dataType isEqualToString:@"float"]);
+    } else {
+        return NO;
+    }
+}
+
 - (void)addFieldsToArray:(NSMutableArray *)modelFields fromDict:(NSDictionary *)dict {
     NSString *field = [dict objectForKey:@"field_name"];
     NSString *dType = [dict objectForKey:@"data_type"];
@@ -383,6 +399,12 @@ NSString * const OTMEnvironmentDateStringShort = @"yyyy-MM-dd";
     if (unit != nil && ![unit isEqualToString:@""]) {
         fmt = [[OTMFormatter alloc] initWithDigits:digits
                                              label:unit];
+    } else if ([self shouldMakeIntFormatterForField:field ofType:dType]) {
+        fmt = [[OTMFormatter alloc] initWithDigits:0
+                                             label:nil];
+    } else if ([self shouldMakeFloatFormatterForField:field ofType:dType]) {
+        fmt = [[OTMFormatter alloc] initWithDigits:2
+                                             label:nil];
     }
 
     if ([field isEqualToString:@"geom"] ||


### PR DESCRIPTION
The application was crashing attempting to convert saved numeric UDF values from numbers to strings, which occurs when showing the edit form with an integer UDF that has a saved value.

Checking the data type of the UDF and creating a numeric formatter for the field when it has the ``int`` or ``float`` type activates the existing numeric field handling, fixing the issue.

The species field has a data type ``int`` (the database id of the selected species) but has highly customized field handling. I exclude it by name to prevent potential negative side effects of having ``fmt`` be non-nil on the species field object.

Connects to #224